### PR TITLE
Improve train data

### DIFF
--- a/data/nlu_data.md
+++ b/data/nlu_data.md
@@ -76,6 +76,38 @@
 - Call me [Sally](name)
 - I am [Philipp](name)
 - I am [Charlie](name)
+- I am [Charlie](name)
+- I am [Ben](name)
+- Call me [Susan](name)
+- [Lucy](name)
+- [Peter](name)
+- [Mark](name)
+- [Joseph](name)
+- [Tan](name)
+- [Pete](name)
+- [Elon](name)
+- [Penny](name)
+- name is [Andrew](name)
+- I [Lora](name)
+- [Stan](name) is my name
+- [Susan](name) is the name
+- [Ross](name) is my first name
+- [Bing](name) is my last name
+- Few call me as [Angelina](name)
+- Some call me [Julia](name)
+- Everyone calls me [Laura](name)
+- I am [Ganesh](name)
+- My name is [Mike](name)
+- just call me [Monika](name)
+- Few call [Dan](name)
+- You can always call me [Suraj](name)
+- Some will call me [Andrew](name)
+- My name is [Ajay](name)
+- I call [Ding](name)
+- I'm [Partia](name)
+- Please call me [Leo](name)
+- name is [Pari](name)
+- name [Sanjay](name)
 
 
 ## intent:joke

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ six==1.11.0
 redis==2.10.6
 fakeredis==0.10.3
 future==0.16.0
-numpy==1.14.5
+numpy~=1.14.5
 typing==3.6.4
 ruamel.yaml==0.15.37
 requests~=2.20
@@ -31,6 +31,6 @@ rasa-core-sdk~=0.12.1
 rasa_core~=0.12.0
 pymongo==3.5.1
 python-dateutil==2.7.3
-spacy==2.0.12
+spacy~=2.0.12
 sklearn_crfsuite==0.3.6
 msgpack==0.5.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ six==1.11.0
 redis==2.10.6
 fakeredis==0.10.3
 future==0.16.0
-numpy~=1.14.5
+numpy~=1.15.0
 typing==3.6.4
 ruamel.yaml==0.15.37
 requests~=2.20


### PR DESCRIPTION
Proposed Changes:

- In requirements.txt:  spacy version 2.0.12 no longer supports UTF-18 while installing spacy English model($ python -m spacy download en"). Latest version of spacy (2.0.18) requires numpy >= 1.15.0

- Added additional training data to nlu intent:name inorder to improve entity extraction efficiency.

Status (please check what you already did):

- [x] made PR ready for code review

- [ ] added some tests for the functionality

- [ ] updated the documentation

- [ ] updated the changelog
